### PR TITLE
refactor(copr): prevent log entries created from user input security#8

### DIFF
--- a/scripts/copr/main.go
+++ b/scripts/copr/main.go
@@ -138,7 +138,13 @@ func cancelBuild(coprUsername string, coprToken string, coprLogin string, buildI
 	}
 
 	// Encode login:token for basic auth (username:password)
-	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", coprLogin, coprToken)))
+	// Sanitize coprLogin and coprToken to remove newline characters
+	sanitizedCoprLogin := strings.ReplaceAll(coprLogin, "\n", "")
+	sanitizedCoprLogin = strings.ReplaceAll(sanitizedCoprLogin, "\r", "")
+	sanitizedCoprToken := strings.ReplaceAll(coprToken, "\n", "")
+	sanitizedCoprToken = strings.ReplaceAll(sanitizedCoprToken, "\r", "")
+
+	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", sanitizedCoprLogin, sanitizedCoprToken)))
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", auth))
 
 	client := &http.Client{}


### PR DESCRIPTION
Fixes [https://github.com/BrycensRanch/Rokon/security/code-scanning/8](https://github.com/BrycensRanch/Rokon/security/code-scanning/8)

To fix the problem, we need to sanitize the user-provided values before logging them. Since the log entry is plain text, we should remove any line breaks from the user input to prevent log forgery. We can use the `strings.ReplaceAll` function to achieve this.

1. Identify the user-provided values (`coprLogin` and `coprToken`).
2. Sanitize these values by removing any newline characters.
3. Use the sanitized values when constructing the `Authorization` header and logging the headers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
